### PR TITLE
Merchant Index Page (stories: 38-41)

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -25,6 +25,7 @@ class AdminsController <ApplicationController
 
   def disable
     merchant = Merchant.find(params[:id])
+    merchant.items.each {|item| item.update_attribute(:active?, false)}
     merchant.update_attribute(:active?, false)
     redirect_to "/admin/merchants"
     flash[:notice] = "disabled #{merchant.name}"
@@ -32,6 +33,7 @@ class AdminsController <ApplicationController
 
   def enable
     merchant = Merchant.find(params[:id])
+    merchant.items.each {|item| item.update_attribute(:active?, true)}
     merchant.update_attribute(:active?, true)
     redirect_to "/admin/merchants"
     flash[:notice] = "enabled #{merchant.name}"

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,5 +1,9 @@
 class AdminsController <ApplicationController
 
+  def index
+    @merchants = Merchant.all
+  end
+
   def show
     if current_user == nil || current_user.role != "admin"
       redirect_to "/error404"
@@ -17,6 +21,13 @@ class AdminsController <ApplicationController
       flash.now[:notice] = new_user.errors.full_messages
       render :new
     end
+  end
+
+  def disable
+    merchant = Merchant.find(params[:id])
+    merchant.update_attribute(:active?, false)
+    redirect_to "/admin/merchants"
+    flash[:notice] = "disabled #{merchant.name}"
   end
 
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -30,4 +30,11 @@ class AdminsController <ApplicationController
     flash[:notice] = "disabled #{merchant.name}"
   end
 
+  def enable
+    merchant = Merchant.find(params[:id])
+    merchant.update_attribute(:active?, true)
+    redirect_to "/admin/merchants"
+    flash[:notice] = "enabled #{merchant.name}"
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,7 +7,8 @@ class Merchant <ApplicationRecord
                         :address,
                         :city,
                         :state,
-                        :zip
+                        :zip,
+                        :active?
 
 
   def no_orders?
@@ -25,5 +26,4 @@ class Merchant <ApplicationRecord
   def distinct_cities
     item_orders.distinct.joins(:order).pluck(:city)
   end
-
 end

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,0 +1,14 @@
+<h1>Admin Index Page</h1>
+
+<h1 align = "center">Merchants</h1>
+<p align="center"><%= link_to "New Merchant", "/merchants/new" %></p>
+<section class= "grid-container">
+  <% @merchants.each do |merchant|%>
+    <section class= <%= "merchant-#{merchant.id}" %>>
+      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+    <% if merchant.active? == true %>
+        <h5><%=link_to "disable", "/admin/disable/#{merchant.id}"%></h5>
+    <% end %>
+    </section>
+  <% end %>
+</section>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -8,6 +8,8 @@
       <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
     <% if merchant.active? == true %>
         <h5><%=link_to "disable", "/admin/disable/#{merchant.id}"%></h5>
+    <% else %>
+        <h5><%=link_to "enable", "/admin/enable/#{merchant.id}"%></h5>
     <% end %>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,8 @@ Rails.application.routes.draw do
 
   #admins
   get "/admin", to: "admins#show"
+  get "/admin/merchants", to: "admins#index"
+  get "/admin/disable/:id", to: "admins#disable"
 
   #errors
   get "error404", to: "errors#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   get "/admin", to: "admins#show"
   get "/admin/merchants", to: "admins#index"
   get "/admin/disable/:id", to: "admins#disable"
+  get "/admin/enable/:id", to: "admins#enable"
 
   #errors
   get "error404", to: "errors#show"

--- a/db/migrate/20200528225538_add_active_to_merchants.rb
+++ b/db/migrate/20200528225538_add_active_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddActiveToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :active?, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200528035143) do
+ActiveRecord::Schema.define(version: 20200528225538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20200528035143) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active?", default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,8 @@ dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', c
 
 #bike_shop items
 tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+tassels = bike_shop.items.create(name: "Handle Bar Tassels", description: "WEEEEeee!!!", active?: true, price: 15, image: "https://images.freeimages.com/images/large-previews/0ba/i-love-pasta-1-1566263.jpg", inventory: 6)
+seat = bike_shop.items.create(name: "Bike Seat", description: "Not for human consumption!", active?: true, price: 105, image: "https://media.istockphoto.com/photos/close-loose-toilet-seat-and-lid-isolated-on-white-picture-id598567074", inventory: 3)
 
 #dog_shop items
 pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -1,38 +1,83 @@
 require 'rails_helper'
 
 RSpec.describe "Admin from their index page (/admin/merchants)" do
+  before(:each) do
+    @merchant1 = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @merchant2 = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    @merchant2.update_attribute(:active?, false)
+    @merchant3 = Merchant.create(name: "Mikes House", address: '23 Just Do It Blvd.', city: 'Denver', state: 'CO', zip: 80208)
+    @item1 = @merchant1.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+    @item2 = @merchant2.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: true, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
+    @item3 = @merchant3.items.create(name: "Handle Bar Tassels", description: "WEEEEeee!!!", active?: true, price: 15, image: "https://images.freeimages.com/images/large-previews/0ba/i-love-pasta-1-1566263.jpg", inventory: 6)
+    @item4 = @merchant3.items.create(name: "Bike Seat", description: "Not for human consumption!", active?: true, price: 105, image: "https://media.istockphoto.com/photos/close-loose-toilet-seat-and-lid-isolated-on-white-picture-id598567074", inventory: 3)
+  end
   it "displays all merchants with functioning buttons to disable and enable merchants" do
-    merch1 = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-    merch2 = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
-    merch2.update_attribute(:active?, false)
-    merch3 = Merchant.create(name: "Mikes House", address: '23 Just Do It Blvd.', city: 'Denver', state: 'CO', zip: 80208)
 
     visit "/admin/merchants"
 
-    within ".merchant-#{merch1.id}" do
+    within ".merchant-#{@merchant1.id}" do
       click_link "disable"
       expect(current_path).to eq("/admin/merchants")
       expect(page).to_not have_link("disable")
       expect(page).to have_link("enable")
     end
 
-    expect(page).to have_content("disabled #{merch1.name}")
+    expect(page).to have_content("disabled #{@merchant1.name}")
 
-    within ".merchant-#{merch2.id}" do
+    within ".merchant-#{@merchant2.id}" do
       click_link "enable"
       expect(current_path).to eq("/admin/merchants")
       expect(page).to have_link("disable")
       expect(page).to_not have_link("enable")
     end
 
-    expect(page).to have_content("enabled #{merch2.name}")
+    expect(page).to have_content("enabled #{@merchant2.name}")
 
-    within ".merchant-#{merch3.id}" do
+    within ".merchant-#{@merchant3.id}" do
       click_link "disable"
       expect(current_path).to eq("/admin/merchants")
       expect(page).to_not have_link("disable")
     end
 
-    expect(page).to have_content("disabled #{merch3.name}")
+    expect(page).to have_content("disabled #{@merchant3.name}")
+  end
+
+  it "enables and disables items belonging to an altered merchant" do
+
+    visit "/items/#{@item3.id}"
+    expect(page).to have_content("Active")
+
+    visit "/admin/merchants"
+
+    within ".merchant-#{@merchant3.id}" do
+      click_link "disable"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("disable")
+      expect(page).to have_link("enable")
+    end
+
+    visit "/items/#{@item3.id}"
+    expect(page).to have_content("Inactive")
+
+    visit "/items/#{@item4.id}"
+    expect(page).to have_content("Inactive")
+
+    visit "/admin/merchants"
+
+    within ".merchant-#{@merchant3.id}" do
+      click_link "enable"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("enable")
+      expect(page).to have_link("disable")
+    end
+
+    visit "/items/#{@item3.id}"
+
+    expect(page).to have_content("Active")
+
+    visit "/admin/merchants"
+
+    visit "/items/#{@item4.id}"
+    expect(page).to have_content("Active")
   end
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Admin index page (/admin/merchants)" do
-  it "displays all merchants with functioning buttons to disable (if active)" do
+RSpec.describe "Admin from their index page (/admin/merchants)" do
+  it "displays all merchants with functioning buttons to disable and enable merchants" do
     merch1 = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
     merch2 = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
     merch2.update_attribute(:active?, false)
@@ -13,13 +13,19 @@ RSpec.describe "Admin index page (/admin/merchants)" do
       click_link "disable"
       expect(current_path).to eq("/admin/merchants")
       expect(page).to_not have_link("disable")
+      expect(page).to have_link("enable")
     end
 
     expect(page).to have_content("disabled #{merch1.name}")
 
     within ".merchant-#{merch2.id}" do
-      expect(page).to_not have_link("disable")
+      click_link "enable"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to have_link("disable")
+      expect(page).to_not have_link("enable")
     end
+
+    expect(page).to have_content("enabled #{merch2.name}")
 
     within ".merchant-#{merch3.id}" do
       click_link "disable"

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Admin index page (/admin/merchants)" do
+  it "displays all merchants with functioning buttons to disable (if active)" do
+    merch1 = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    merch2 = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    merch2.update_attribute(:active?, false)
+    merch3 = Merchant.create(name: "Mikes House", address: '23 Just Do It Blvd.', city: 'Denver', state: 'CO', zip: 80208)
+
+    visit "/admin/merchants"
+
+    within ".merchant-#{merch1.id}" do
+      click_link "disable"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("disable")
+    end
+
+    expect(page).to have_content("disabled #{merch1.name}")
+
+    within ".merchant-#{merch2.id}" do
+      expect(page).to_not have_link("disable")
+    end
+
+    within ".merchant-#{merch3.id}" do
+      click_link "disable"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("disable")
+    end
+
+    expect(page).to have_content("disabled #{merch3.name}")
+  end
+end


### PR DESCRIPTION
Completed stories 38-41, need to look into implementing a partial for enabling and disabling merchants and or items. 


Add column to merchants, Complete story 38, All tests passing

Refactor admin index_spec for story 40, Add enable link for merchants

Add admin 'enable' route and action (probably should refactor w/ a partial)

Add functionality to disabled/enable a merchants items based on merchant status